### PR TITLE
Add configurable rollover and move shortcuts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,9 @@ const settingsStore = new Store({
         preferences: process.platform === 'darwin' ? 'Cmd+,' : 'Ctrl+,',
         devTools: process.platform === 'darwin' ? 'Cmd+Option+I' : 'F12'
       }
+    },
+    behavior: {
+      enableTodoRollover: true
     }
   }
 });
@@ -237,8 +240,15 @@ function createTray(): void {
 function rolloverTodos(): void {
   const today = new Date().toISOString().split('T')[0];
   const lastAccessed = store.get('lastAccessed');
+  const rolloverSetting = settingsStore.get('behavior.enableTodoRollover');
+  const isRolloverEnabled = rolloverSetting !== false;
   
   if (lastAccessed !== today) {
+    if (!isRolloverEnabled) {
+      store.set('lastAccessed', today);
+      return;
+    }
+
     const todos = store.get('todos');
     
     // Find the most recent date with todos (excluding today)

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -606,6 +606,26 @@ body {
   font-weight: 500;
 }
 
+.setting-item-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.setting-item-description {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.55);
+  line-height: 1.4;
+}
+
+.setting-checkbox {
+  width: 16px;
+  height: 16px;
+  accent-color: #3b82f6;
+  cursor: pointer;
+}
+
 .shortcut-input {
   display: flex;
   align-items: center;
@@ -995,6 +1015,10 @@ kbd {
 
   .setting-item label {
     color: rgba(255, 255, 255, 0.8);
+  }
+
+  .setting-item-description {
+    color: rgba(255, 255, 255, 0.6);
   }
 
   .shortcut-input {

--- a/src/renderer/components/PreferencesModal.tsx
+++ b/src/renderer/components/PreferencesModal.tsx
@@ -86,7 +86,7 @@ const PreferencesModal: React.FC = () => {
               <div className="preferences-panel">
                 {activeTab === 'keybindings' && <KeybindingsPanel />}
                 {activeTab === 'appearance' && <ComingSoonPanel title="Appearance" />}
-                {activeTab === 'behavior' && <ComingSoonPanel title="Behavior" />}
+                {activeTab === 'behavior' && <BehaviorPanel />}
               </div>
             </div>
           </motion.div>
@@ -291,6 +291,16 @@ const KeybindingsPanel: React.FC = () => {
           path="keybindings.navigation.nextDay"
           defaultValue="ArrowRight"
         />
+        <ShortcutInput 
+          label="Move Todo Up"
+          path="keybindings.navigation.moveTodoUp"
+          defaultValue={platform === 'darwin' ? 'Cmd+ArrowUp' : 'Ctrl+ArrowUp'}
+        />
+        <ShortcutInput 
+          label="Move Todo Down"
+          path="keybindings.navigation.moveTodoDown"
+          defaultValue={platform === 'darwin' ? 'Cmd+ArrowDown' : 'Ctrl+ArrowDown'}
+        />
       </div>
       
       <div className="setting-section">
@@ -344,6 +354,38 @@ const KeybindingsPanel: React.FC = () => {
         >
           Reset to Defaults
         </button>
+      </div>
+    </div>
+  );
+};
+
+const BehaviorPanel: React.FC = () => {
+  const { settings, updateSetting } = usePreferencesStore();
+
+  return (
+    <div className="panel-content">
+      <h3>Behavior</h3>
+      <p className="panel-description">
+        Control how TodoCmd handles unfinished todos between days.
+      </p>
+
+      <div className="setting-section">
+        <h4>Todo Management</h4>
+        <div className="setting-item">
+          <div className="setting-item-copy">
+            <label htmlFor="enable-todo-rollover">Enable todo rollover</label>
+            <p className="setting-item-description">
+              Carry incomplete todos into today on the first launch each day.
+            </p>
+          </div>
+          <input
+            id="enable-todo-rollover"
+            className="setting-checkbox"
+            type="checkbox"
+            checked={settings.behavior.enableTodoRollover}
+            onChange={(e) => updateSetting('behavior.enableTodoRollover', e.target.checked)}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/hooks/useKeyboardNavigation.ts
+++ b/src/renderer/hooks/useKeyboardNavigation.ts
@@ -64,6 +64,8 @@ export const useKeyboardNavigation = () => {
 
     // Get keybindings from settings
     const keybindings = settings.keybindings;
+    const moveUpShortcut = keybindings.navigation.moveTodoUp;
+    const moveDownShortcut = keybindings.navigation.moveTodoDown;
 
     switch (e.key) {
       case 'Escape':
@@ -95,8 +97,8 @@ export const useKeyboardNavigation = () => {
       case 'ArrowUp':
         e.preventDefault();
         if (mode === 'view' && todos.length > 0) {
-          // Ctrl+ArrowUp: Move selected item up
-          if (e.ctrlKey && selectedIndex > 0) {
+          // Move selected item up (configurable shortcut)
+          if (matchesShortcut(e, moveUpShortcut) && selectedIndex > 0) {
             moveTodo(selectedIndex, selectedIndex - 1);
           } else {
             // Regular ArrowUp: Navigate to previous item
@@ -108,8 +110,8 @@ export const useKeyboardNavigation = () => {
       case 'ArrowDown':
         e.preventDefault();
         if (mode === 'view' && todos.length > 0) {
-          // Ctrl+ArrowDown: Move selected item down
-          if (e.ctrlKey && selectedIndex < todos.length - 1) {
+          // Move selected item down (configurable shortcut)
+          if (matchesShortcut(e, moveDownShortcut) && selectedIndex < todos.length - 1) {
             moveTodo(selectedIndex, selectedIndex + 1);
           } else {
             // Regular ArrowDown: Navigate to next item
@@ -173,6 +175,16 @@ export const useKeyboardNavigation = () => {
             if (mode === 'view') {
               setCurrentDate(addDays(currentDate, 1));
             }
+          }
+          // Move todo up (for remaps that are not ArrowUp)
+          else if (matchesShortcut(e, moveUpShortcut) && todos.length > 0 && selectedIndex > 0) {
+            e.preventDefault();
+            moveTodo(selectedIndex, selectedIndex - 1);
+          }
+          // Move todo down (for remaps that are not ArrowDown)
+          else if (matchesShortcut(e, moveDownShortcut) && todos.length > 0 && selectedIndex < todos.length - 1) {
+            e.preventDefault();
+            moveTodo(selectedIndex, selectedIndex + 1);
           }
           // Status shortcuts with toggle functionality
           else if (matchesShortcut(e, keybindings.navigation.markImportant) && todos.length > 0) {

--- a/src/renderer/store/preferencesStore.ts
+++ b/src/renderer/store/preferencesStore.ts
@@ -12,7 +12,7 @@ interface PreferencesStore {
   openPreferences: () => void;
   closePreferences: () => void;
   setActiveTab: (tab: string) => void;
-  updateSetting: (path: string, value: string) => void;
+  updateSetting: (path: string, value: string | boolean) => void;
   resetToDefaults: () => void;
   loadSettings: () => Promise<void>;
   saveSettings: () => Promise<void>;
@@ -137,6 +137,10 @@ export const usePreferencesStore = create<PreferencesStore>((set, get) => ({
               ...platformSpecificDefaults.keybindings.system,
               ...loadedSettings.keybindings?.system,
             },
+          },
+          behavior: {
+            ...platformSpecificDefaults.behavior,
+            ...loadedSettings.behavior,
           },
         };
         set({ settings: mergedSettings });

--- a/src/renderer/types/settings.ts
+++ b/src/renderer/types/settings.ts
@@ -12,6 +12,8 @@ export interface AppSettings {
       checkUpdates: string;
       previousDay: string;
       nextDay: string;
+      moveTodoUp: string;
+      moveTodoDown: string;
       // Todo status shortcuts
       markImportant: string;
       markInProgress: string;
@@ -28,7 +30,7 @@ export interface AppSettings {
     // Future settings
   };
   behavior: {
-    // Future settings
+    enableTodoRollover: boolean;
   };
 }
 
@@ -52,6 +54,8 @@ export const defaultSettings: AppSettings = {
       checkUpdates: "u",
       previousDay: "ArrowLeft",
       nextDay: "ArrowRight",
+      moveTodoUp: "Ctrl+ArrowUp",
+      moveTodoDown: "Ctrl+ArrowDown",
       // Todo status shortcuts - will be updated to platform-specific by preferences store
       markImportant: "Ctrl+I",
       markInProgress: "Ctrl+P",
@@ -65,7 +69,9 @@ export const defaultSettings: AppSettings = {
     },
   },
   appearance: {},
-  behavior: {},
+  behavior: {
+    enableTodoRollover: true,
+  },
 };
 
 // Helper function to get platform-specific defaults
@@ -79,6 +85,8 @@ export const getPlatformSpecificDefaults = (platform: string) => {
     markOnHold: `${modifierKey}+H`,
     markCompleted: `${modifierKey}+C`,
     markCancelled: `${modifierKey}+X`,
+    moveTodoUp: `${modifierKey}+ArrowUp`,
+    moveTodoDown: `${modifierKey}+ArrowDown`,
     preferences: `${modifierKey}+,`,
   };
 };


### PR DESCRIPTION
This PR makes todo rollover configurable in Preferences > Behavior (enabled by default) and applies that setting in the main rollover logic. It also adds remappable move shortcuts for todo ordering, with defaults of Cmd+Arrow on macOS and Ctrl+Arrow on Windows/Linux. The keybindings panel now exposes Move Todo Up/Down, and settings loading merges behavior defaults for existing configs.